### PR TITLE
chore(deps-dev): downgrade @biomejs/biome to 1.9.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v4
       - name: Setup Biome CLI
         uses: biomejs/setup-biome@v2
       - run: biome --version

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "devDependencies": {
-    "@biomejs/biome": "1.9.4"
+    "@biomejs/biome": "1.9.3"
   }
 }


### PR DESCRIPTION
Logs indicate that biome@latest is installed, , i.e. 1.9.4, even though package.json devDependencies mention 1.9.3

https://github.com/trivikr/test-setup-biome-from-deps/actions/runs/14053169659/job/39347110945?pr=1